### PR TITLE
Remove client_id from source

### DIFF
--- a/Domai.nr/plugins/domainr/__init__.py
+++ b/Domai.nr/plugins/domainr/__init__.py
@@ -229,7 +229,7 @@ class Domainr(object):
         # seem to be able to encode unicode strings properly)
         # Alters payload in-place, but this is a "private" method, and we don't
         # reuse is after this call anyway.
-        payload["client_id"] = "Ultros-Domai.nr"
+        payload["client_id"] = "{your-mashape-key}"
         for k, v in payload.iteritems():
             if isinstance(v, unicode):
                 payload[k] = v.encode("utf8")


### PR DESCRIPTION
Due to API abuse, we're locking these down further. Details in our [API documentation](http://domainr.build/docs/authentication).